### PR TITLE
Added health-check endpoint

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -74,5 +74,6 @@ jobs:
         with:
           context: .
           push: true
-          tags: fsergeev/keepup-base-app:master-01
+          # todo set tag
+          tags: fsergeev/keepup-base-app:healthcheck-01
           build-args: JAR_FILE=build/libs/keepup-base-app-1.0-SNAPSHOT.jar

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,10 @@ dependencies {
     implementation 'org.apache.poi:poi:5.0.0'
     implementation 'org.apache.poi:poi-ooxml:5.0.0'
 
+    testImplementation 'org.junit.platform:junit-platform-runner:1.7.2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'io.projectreactor:reactor-test'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
 }

--- a/src/main/java/io/keepup/cms/projects/rest/HealthCheckController.java
+++ b/src/main/java/io/keepup/cms/projects/rest/HealthCheckController.java
@@ -1,0 +1,27 @@
+package io.keepup.cms.projects.rest;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+/**
+ * Simple controller with endpoint for controlling application health
+ *
+ * @author Fedor Sergeev
+ */
+@RestController
+@RequestMapping("/health")
+public class HealthCheckController {
+
+    private final Log log = LogFactory.getLog(getClass());
+
+    @GetMapping
+    public Mono<ResponseEntity<String>> health() {
+        log.debug("Health check requested");
+        return Mono.just(ResponseEntity.ok("OK"));
+    }
+}

--- a/src/main/resources/application-security.yaml
+++ b/src/main/resources/application-security.yaml
@@ -1,8 +1,8 @@
 keepup:
   security:
     enabled: true
-    path-matchers: /user,/content,/file
-    permitted-urls: /test
+    path-matchers: /user
+    permitted-urls: /health
     login-url: login
     logout-url: logout
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,9 +5,10 @@ spring:
 logging:
   level:
     root: INFO
+    io.keepup.cms.projects.rest: DEBUG
 keepup:
   paths:
-    static1: /app/static
+    static: /app/static
   plugins:
     catalog:
       enabled: true

--- a/src/test/java/io/keepup/cms/projects/rest/HealthCheckControllerTest.java
+++ b/src/test/java/io/keepup/cms/projects/rest/HealthCheckControllerTest.java
@@ -1,0 +1,68 @@
+package io.keepup.cms.projects.rest;
+
+import io.keepup.cms.core.boot.KeepupApplication;
+import io.keepup.cms.core.cache.CacheAdapter;
+import io.keepup.cms.core.cache.KeepupCacheConfiguration;
+import io.keepup.cms.core.config.DataSourceConfiguration;
+import io.keepup.cms.core.config.R2dbcConfiguration;
+import io.keepup.cms.core.config.SecurityConfiguration;
+import io.keepup.cms.core.config.WebFluxConfig;
+import io.keepup.cms.core.datasource.dao.DataSourceFacadeImpl;
+import io.keepup.cms.core.datasource.dao.sql.SqlContentDao;
+import io.keepup.cms.core.datasource.dao.sql.SqlFileDao;
+import io.keepup.cms.core.datasource.dao.sql.SqlUserDao;
+import io.keepup.cms.core.datasource.sql.repository.ReactiveNodeAttributeEntityRepository;
+import io.keepup.cms.core.datasource.sql.repository.ReactiveNodeEntityRepository;
+import io.keepup.cms.core.datasource.sql.repository.ReactiveUserEntityRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@ActiveProfiles({"dev", "h2", "security"})
+@WebFluxTest(HealthCheckController.class)
+@AutoConfigureWebTestClient
+@RunWith(SpringRunner.class)
+@TestPropertySource(properties = {
+        "keepup.security.permitted-urls=/health",
+        "keepup.security.csrf-enabled=false"
+})
+@ContextConfiguration(classes = {
+        BCryptPasswordEncoder.class,
+        SecurityWebFilterChain.class,
+        SecurityConfiguration.class,
+        KeepupApplication.class,
+        KeepupCacheConfiguration.class,
+        CacheAdapter.class,
+        WebFluxConfig.class,
+        ReactiveNodeEntityRepository.class,
+        ReactiveNodeAttributeEntityRepository.class,
+        ReactiveUserEntityRepository.class,
+        DataSourceConfiguration.class,
+        R2dbcConfiguration.class,
+        SqlContentDao.class,
+        SqlFileDao.class,
+        SqlUserDao.class,
+        DataSourceFacadeImpl.class
+})
+class HealthCheckControllerTest {
+
+    @Autowired
+    private WebTestClient webClient;
+
+    @Test
+    void health() {
+        webClient.get()
+                .uri("/health")
+                .exchange()
+                .expectStatus().isOk();
+    }
+}


### PR DESCRIPTION
Method GET with URL /healh, no request parameters. Endpoint is added to the list of permitted URLs in security configuration (activeted in profile 'security'). Method returns OK and 200 HTTP status in case if application is alive.